### PR TITLE
Git lfs proto

### DIFF
--- a/doc/PKGBUILD.5.asciidoc
+++ b/doc/PKGBUILD.5.asciidoc
@@ -472,7 +472,7 @@ control system (VCS) is enabled by specifying the source in the form:
 
 	source=('directory::url#fragment?query')
 
-Currently makepkg supports the Bazaar, Git, Subversion, and Mercurial version
+Currently makepkg supports the Bazaar, Git, Git-lfs, Subversion, and Mercurial version
 control systems. For other version control systems, manual cloning of upstream
 repositories must be done in the `prepare()` function.
 
@@ -500,6 +500,9 @@ The source URL is divided into four components:
 		revision (see `'bzr help revisionspec'` for details)
 
 	*git*;;
+		branch, commit, tag
+
+	*git-lfs*;;
 		branch, commit, tag
 
 	*hg*;;

--- a/scripts/libmakepkg/source/git-lfs.sh.in
+++ b/scripts/libmakepkg/source/git-lfs.sh.in
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+#   git-lfs.sh - function for handling the download and "extraction" of Git Large File Storage sources
+#
+#   Copyright (c) 2015-2020 Pacman Development Team <pacman-dev@archlinux.org>
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+[[ -n "$LIBMAKEPKG_SOURCE_GIT_SH" ]] && return
+LIBMAKEPKG_SOURCE_GIT_SH=1
+
+
+LIBRARY=${LIBRARY:-'@libmakepkgdir@'}
+
+source "$LIBRARY/util/message.sh"
+source "$LIBRARY/util/pkgbuild.sh"
+source "$LIBRARY/source/git.sh"
+
+download_git-lfs() {
+  local url="${1/git-lfs+/git+}" dir
+  dir="$SRCDEST/$(get_filename "$url")"
+  download_git "$url"
+  git -C "$dir" lfs install
+  git -C "$dir" lfs fetch
+}
+
+extract_git-lfs() {
+  local url=${1/git-lfs+/git+}
+  extract_git "$url"
+}
+


### PR DESCRIPTION
Allow makepkg to handle Git repository with lfs extension
by introducing new protocol 'git-lfs' to use in PKGBUILD source array.

Implementation of {download,extract}_git-lfs wraps {download,extract}_git.

!Requires adding 'git-lfs::git-lfs' to VCSCLIENTS array in makepkg.conf.